### PR TITLE
Added support for drag interactions on the alphabet list widget

### DIFF
--- a/lib/src/sectionView.dart
+++ b/lib/src/sectionView.dart
@@ -194,7 +194,7 @@ class _SectionViewState<T, N> extends State<SectionView> {
           alphabetAlign: ownWidget.alphabetAlign,
           alphabetInset: ownWidget.alphabetInset,
           key: sectionViewAlphabetListKey,
-          onTap: <T>(item) {
+          onSelect: <T>(item) {
             if (alphabetTipKey.currentState != null) {
               alphabetTipKey.currentState!.tipData = item.headerData;
             }

--- a/lib/src/sectionViewAlphabetList.dart
+++ b/lib/src/sectionViewAlphabetList.dart
@@ -51,19 +51,21 @@ class SectionViewAlphabetListState<T> extends State<SectionViewAlphabetList> {
 
   void onDrag(double yPosition) {
     double checkedHeight = 0;
-    int index = 0;
+    int? index;
 
     // To determine which widget is selected add the height of every alphabet item one by one
     // Until the height is in range of the drag position
     // At that point we have determined the index of the header item and trigger the callback with that item
-    while(checkedHeight < yPosition && index < ownWidget.headerToIndexMap.length) {
-      double itemHeight = itemKeys[index].currentContext?.size?.height ?? 0;
+    for (var i = 0; i < ownWidget.headerToIndexMap.length; i++) {
+      double itemHeight = itemKeys[i].currentContext?.size?.height ?? 0;
       checkedHeight += itemHeight;
-      index += 1;
+      if (checkedHeight >= yPosition) {
+        index = i;
+        break;
+      }
     }
 
-    index = max(index - 1, 0);
-    if (index < ownWidget.headerToIndexMap.length && index >= 0) {
+    if (index != null) {
       ownWidget.onSelect(ownWidget.headerToIndexMap[index]);
     }
   }


### PR DESCRIPTION
As the title already describes, I have added the ability to drag across the alphabet list like a native iOS element would do (for example in the Contacts app). Gives a bit more control, because the items in the last can be a bit small